### PR TITLE
fix: required deposit fix when available storage is higher than needed

### DIFF
--- a/src/utils/calculateRequiredDeposit/calculateRequiredDeposit.test.ts
+++ b/src/utils/calculateRequiredDeposit/calculateRequiredDeposit.test.ts
@@ -109,12 +109,12 @@ describe('calculateRequiredDeposit()', () => {
         data,
         storageBalance: {
           available: BigInt(storageCostOfData.plus('1').toFixed()),
-          total: BigInt(storageCostOfData.minus('1').toFixed()),
+          total: BigInt(storageCostOfData.plus('10').toFixed()),
         },
       });
 
       // assert
-      expect(result.toFixed()).toBe('1');
+      expect(result.toFixed()).toBe('0');
     });
   });
 });

--- a/src/utils/calculateRequiredDeposit/calculateRequiredDeposit.ts
+++ b/src/utils/calculateRequiredDeposit/calculateRequiredDeposit.ts
@@ -48,5 +48,5 @@ export default function calculateRequiredDeposit({
   // if the storage deposit available is less than the cost of storage, use the difference as the required deposit
   return storageDepositAvailable.lt(storageCostOfData)
     ? storageCostOfData.minus(storageDepositAvailable)
-    : new BigNumber(ONE_YOCTO);
+    : new BigNumber('0');
 }

--- a/src/utils/calculateRequiredDeposit/calculateRequiredDeposit.ts
+++ b/src/utils/calculateRequiredDeposit/calculateRequiredDeposit.ts
@@ -3,7 +3,6 @@ import BigNumber from 'bignumber.js';
 // constants
 import {
   MINIMUM_STORAGE_IN_BYTES,
-  ONE_YOCTO,
   STORAGE_COST_PER_BYTES_IN_ATOMIC_UNITS,
 } from '@app/constants';
 import { EXTRA_STORAGE_BALANCE } from './constants';


### PR DESCRIPTION
When the available storage for on account is greater than the required storage for new data, we attach 0 deposit, hence making the transaction gas-only and also skipping the re-direction to the web wallet. 

Gas-only transactions by limited access keys which are specific to apps and enable an experience where you don't have to open wallet every time to confirm a transaction is one of the important and attractive features of Near's account model. 
This is also what makes usage on Near.social smoother. 

This PR, removes the 1 yocto deposit for the above mentioned case and replace it with 0 deposit instead. 

PS: I know total storage is never used in the requiredDeposit calculation but I still changed it cause it was factually incorrect, total storage can never be less than available storage. 


<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests
