### PR TITLE
fix: serialize BigInt in fetchFromApi for API server calls

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -53,7 +53,9 @@ export class Graph {
     const response = await fetch(this.apiServer + endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+      body: JSON.stringify(body, (key, value) =>
+        typeof value === 'bigint' ? value.toString() : value
+      ),
     });
     return response.json();
   }


### PR DESCRIPTION
## Summary

- Fixed `BigInt` serialization error in `fetchFromApi` method
- `JSON.stringify` cannot serialize `BigInt` natively, so added a replacer function
- Fixes `getPost()` failing with `TypeError: Do not know how to serialize a BigInt`

## Testing

```javascript
const post = await social.getPost('sleet.near', 162929907);
// Returns: { type: 'md', text: 'what is the post count for near social?' }
```

## Fixes

Fixes #61